### PR TITLE
Enable local client build mode

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 using Vite.AspNetCore;
+using AspNetViteMpa.Utilities;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,8 +9,11 @@ builder.Services.AddViteServices();
 
 var app = builder.Build();
 
+var useVite = builder.Configuration.UseVite();
+var isDevelopment = builder.Environment.IsDevelopment();
+
 // Configure the HTTP request pipeline.
-if (!app.Environment.IsDevelopment())
+if (!isDevelopment)
 {
     app.UseExceptionHandler("/Home/Error");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
@@ -31,10 +35,13 @@ app.MapControllerRoute(
 
 app.MapGet("/api/hello", () => "Hello from the Server");
 
-if (app.Environment.IsDevelopment())
+if (isDevelopment)
 {
     app.UseWebSockets();
-    app.UseViteDevelopmentServer(true);
+    if (useVite)
+    {
+        app.UseViteDevelopmentServer(true);
+    }
 }
 
 app.Run();

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,19 +1,20 @@
 {
   "profiles": {
-    "http": {
+    "vite": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_VITE": "true"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5208"
+      "applicationUrl": "https://localhost:7025;http://localhost:5208"
     },
-    "https": {
+    "build": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
       },
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:7025;http://localhost:5208"

--- a/Utilities/ConfigurationExtensions.cs
+++ b/Utilities/ConfigurationExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace AspNetViteMpa.Utilities
+{
+    public static class ConfigurationExtensions
+    {
+        public static bool UseVite(this ConfigurationManager configuration)
+        {
+            return configuration["ASPNETCORE_VITE"]?.ToLower() == "true";
+        }
+    }
+}


### PR DESCRIPTION
Break up the default `https` launch settings entry into two settings called `vite` and `build`. Simply, when launching the `vite` profile, vite is enabled and when launching `build`, the local server expects to see the built version of the client, including the manifest.json file.